### PR TITLE
Hotfix/doctrine module 0.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": ">=5.4",
-        "doctrine/doctrine-module": "^0.9",
+        "doctrine/doctrine-module": "^0.8",
         "zendframework/zend-modulemanager": "^2.5",
         "zendframework/zend-mvc": "^2.5",
         "zendframework/zend-servicemanager": "^2.5",


### PR DESCRIPTION
Because of the blockage caused by 
https://github.com/doctrine/mongodb-odm/issues/1364 https://github.com/doctrine/DoctrineModule/issues/546

This module does not actually require 0.9 of doctrine-module so rolling back to ^0.8