### PR TITLE
Add support to Match Against

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -13,4 +13,13 @@ return array(
             'ZfDoctrineQueryBuilderOrderByManagerOdm' => 'ZF\Doctrine\QueryBuilder\OrderBy\Service\ODMOrderByManagerFactory',
         ),
     ),
+    'doctrine' => array(
+        'configuration' => array(
+            'orm_default' => array(
+                'string_functions' => array(
+                    'MATCH' => 'DoctrineExtensions\Query\MySql\MatchAgainst'
+                )
+            )
+        ),
+    ),
 );

--- a/config/zf-doctrine-querybuilder.global.php.dist
+++ b/config/zf-doctrine-querybuilder.global.php.dist
@@ -37,6 +37,7 @@ return array(
             'ismemberof' => 'ZF\Doctrine\QueryBuilder\Filter\ORM\IsMemberOf',
             'orx' => 'ZF\Doctrine\QueryBuilder\Filter\ORM\OrX',
             'andx' => 'ZF\Doctrine\QueryBuilder\Filter\ORM\AndX',
+            'match' => 'ZF\Doctrine\QueryBuilder\Filter\ORM\MatchAgainst',
         ),
     ),
 

--- a/src/Filter/ORM/MatchAgainst.php
+++ b/src/Filter/ORM/MatchAgainst.php
@@ -50,11 +50,5 @@ class MatchAgainst extends AbstractFilter
             ->setParameter('searchterm', $option['value'])
             ->orderBy('match_score', 'desc');
         
-        // $queryBuilder->$queryType(
-        // $queryBuilder
-        // ->expr()
-        // ->gt($option['alias'] . '.' . $option['field'], ':' . $parameter)
-        // );
-        // $queryBuilder->setParameter($parameter, $value);
     }
 }

--- a/src/Filter/ORM/MatchAgainst.php
+++ b/src/Filter/ORM/MatchAgainst.php
@@ -41,8 +41,8 @@ class MatchAgainst extends AbstractFilter
             $option['field'] = "{$option['alias']}.{$option['field']}";
         }
         
-        $queryBuilder->addSelect("MATCH ({$option['field']}) AGAINST (:searchterm) AS match_score")
-            ->add('where', "MATCH ({$option['field']}) AGAINST (:searchterm) > 0.8")
+        $queryBuilder->addSelect("MATCH ({$option['field']}) AGAINST (:searchterm boolean) AS HIDDEN match_score")
+            ->add('where', "MATCH ({$option['field']}) AGAINST (:searchterm boolean) > 0.8")
             ->setParameter('searchterm', $option['value'])
             ->orderBy('match_score', 'desc');
     }

--- a/src/Filter/ORM/MatchAgainst.php
+++ b/src/Filter/ORM/MatchAgainst.php
@@ -6,6 +6,7 @@ class MatchAgainst extends AbstractFilter
 
     public function filter($queryBuilder, $metadata, $option)
     {
+        /* @var $queryBuilder \Doctrine\ORM\QueryBuilder */
         if (isset($option['where'])) {
             if ($option['where'] === 'and') {
                 $queryType = 'andWhere';
@@ -26,18 +27,13 @@ class MatchAgainst extends AbstractFilter
         
         $value = $this->typeCastField($metadata, $option['field'], $option['value'], $format);
         
-        // $parameter = uniqid('a');
-        
-        if (! is_array($option['field'])) {
-            if (strpos($option['field'], ',') !== false) {
-                $option['field'] = explode(',', $option['field']);
-            }
+        if (strpos($option['field'], ',') !== false) {
+            $option['field'] = explode(',', $option['field']);
         }
         
         if (is_array($option['field'])) {
             $fields = array();
             foreach ($option['field'] as $field) {
-                $field = utf8_encode($field);
                 $fields[] = "{$option['alias']}.{$field}";
             }
             $option['field'] = implode(',', $fields);
@@ -45,10 +41,9 @@ class MatchAgainst extends AbstractFilter
             $option['field'] = "{$option['alias']}.{$option['field']}";
         }
         
-        $queryBuilder->addSelect("MATCH ({$option['field']}) AGAINST (:searchterm) match_score")
+        $queryBuilder->addSelect("MATCH ({$option['field']}) AGAINST (:searchterm) AS match_score")
             ->add('where', "MATCH ({$option['field']}) AGAINST (:searchterm) > 0.8")
             ->setParameter('searchterm', $option['value'])
             ->orderBy('match_score', 'desc');
-        
     }
 }

--- a/src/Filter/ORM/MatchAgainst.php
+++ b/src/Filter/ORM/MatchAgainst.php
@@ -1,0 +1,60 @@
+<?php
+namespace ZF\Doctrine\QueryBuilder\Filter\ORM;
+
+class MatchAgainst extends AbstractFilter
+{
+
+    public function filter($queryBuilder, $metadata, $option)
+    {
+        if (isset($option['where'])) {
+            if ($option['where'] === 'and') {
+                $queryType = 'andWhere';
+            } elseif ($option['where'] === 'or') {
+                $queryType = 'orWhere';
+            }
+        }
+        
+        if (! isset($queryType)) {
+            $queryType = 'andWhere';
+        }
+        
+        if (! isset($option['alias'])) {
+            $option['alias'] = 'row';
+        }
+        
+        $format = isset($option['format']) ? $option['format'] : null;
+        
+        $value = $this->typeCastField($metadata, $option['field'], $option['value'], $format);
+        
+        // $parameter = uniqid('a');
+        
+        if (! is_array($option['field'])) {
+            if (strpos($option['field'], ',') !== false) {
+                $option['field'] = explode(',', $option['field']);
+            }
+        }
+        
+        if (is_array($option['field'])) {
+            $fields = array();
+            foreach ($option['field'] as $field) {
+                $field = utf8_encode($field);
+                $fields[] = "{$option['alias']}.{$field}";
+            }
+            $option['field'] = implode(',', $fields);
+        } else {
+            $option['field'] = "{$option['alias']}.{$option['field']}";
+        }
+        
+        $queryBuilder->addSelect("MATCH ({$option['field']}) AGAINST (:searchterm) match_score")
+            ->add('where', "MATCH ({$option['field']}) AGAINST (:searchterm) > 0.8")
+            ->setParameter('searchterm', $option['value'])
+            ->orderBy('match_score', 'desc');
+        
+        // $queryBuilder->$queryType(
+        // $queryBuilder
+        // ->expr()
+        // ->gt($option['alias'] . '.' . $option['field'], ':' . $parameter)
+        // );
+        // $queryBuilder->setParameter($parameter, $value);
+    }
+}

--- a/test/Filter/ORMFilterTest.php
+++ b/test/Filter/ORMFilterTest.php
@@ -902,11 +902,13 @@ class ORMFilterTest extends AbstractHttpControllerTestCase
     {
         $filters = array(
             array(
-                'field' => 'name',
+                'field' => 'name', // optional : field can be separated by ',' like : 'field' => 'field1,field2'
                 'type' => 'match',
                 'value' => 'Five',
             ),
         );
+        
+       
     
         $this->assertEquals(1, $this->countResult($filters));
     }

--- a/test/Filter/ORMFilterTest.php
+++ b/test/Filter/ORMFilterTest.php
@@ -898,4 +898,16 @@ class ORMFilterTest extends AbstractHttpControllerTestCase
 
         $this->assertEquals(2, $this->countResult($filters, 'Db\Entity\Album'));
     }
+    public function testMatchAgainst()
+    {
+        $filters = array(
+            array(
+                'field' => 'name',
+                'type' => 'match',
+                'value' => 'Five',
+            ),
+        );
+    
+        $this->assertEquals(1, $this->countResult($filters));
+    }
 }

--- a/test/Filter/local.php
+++ b/test/Filter/local.php
@@ -41,6 +41,7 @@ return array(
             'orx' => 'ZF\Doctrine\QueryBuilder\Filter\ORM\OrX',
             'andx' => 'ZF\Doctrine\QueryBuilder\Filter\ORM\AndX',
             'innerjoin' => 'ZF\Doctrine\QueryBuilder\Filter\ORM\InnerJoin',
+            'match' => 'ZF\Doctrine\QueryBuilder\Filter\ORM\MatchAgainst',
         ),
     ),
 


### PR DESCRIPTION
This PR need some modifications to work properly

This is original json returned by api :

```
"_embedded": {
    "produtos": [
      {
        "id": 1,
        "codigobarras": "7891317430436",
        "ncm": 30049099,
        "origemmercadoria": 0,
        ...
```

And this is after match against

```
"_embedded": {
    "produtos": [
      {
        "match_score": "8.799543380737305",
        "_embedded": [
          {
            "id": 396,
            "codigobarras": "7896112146124",
            "ncm": null,
            "origemmercadoria": 0,
           ...
```

Any suggestions to not break compatibility?

In my personal case i need post process the result so this does not matter, but this is not intendeed behaviour
