### PR TITLE
Update orm query provider

### DIFF
--- a/src/Query/Provider/DefaultOrm.php
+++ b/src/Query/Provider/DefaultOrm.php
@@ -79,8 +79,8 @@ class DefaultOrm implements ObjectManagerAwareInterface, QueryProviderInterface,
      */
     public function createQuery(ResourceEvent $event, $entityClass, $parameters)
     {
-        $request = $this->getServiceLocator()->getServiceLocator()
-            ->get('ControllerPluginManager')->get('params')->fromQuery();
+        $request = $this->getServiceLocator()
+            ->getServiceLocator()->get('Application')->getRequest()->getQuery()->toArray();
 
         $queryBuilder = $this->getObjectManager()->createQueryBuilder();
         $queryBuilder->select('row')


### PR DESCRIPTION
Update the ORM query provider's createQuery() method to get the request's query string parameters from the application, not the Params controller plugin.

Fixes #31.